### PR TITLE
AFUP Day 2024 sur lyon.afup.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ ga_ua: "G-KRC2L7ZCZC"
 home_featured_articles_count: 2
 
 subheader:
-  - label: AFUP DAY 2023
+  - label: AFUP DAY 2024
     url: "https://event.afup.org"
     icon: calendar
   - label: Appel à speakers


### PR DESCRIPTION
On affiche AFUP Day 2024 sur la home de lyon.afup.org au lieu de AFUP Day 2023